### PR TITLE
Revert "Remove explicit permission from on push develop"

### DIFF
--- a/.github/workflows/on_push-develop.yml
+++ b/.github/workflows/on_push-develop.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+
 jobs:
   onPushDevelopJob:
     name: Verify code base when pushed


### PR DESCRIPTION
Reverts alphagov/di-mobile-android-onelogin-app#22

This ID token is required for the AWS credentials from assuming the mobile secrets role to persist.

Successfully tested on branch deployment here - https://github.com/alphagov/di-mobile-android-onelogin-app/actions/runs/6272447727