### PR TITLE
[DCMAW-6679] Update aws-secrets-manager-actions version to 2.2.1

### DIFF
--- a/config/actions/retrieve-secrets/action.yml
+++ b/config/actions/retrieve-secrets/action.yml
@@ -18,13 +18,13 @@ runs:
         role-skip-session-tagging: true
 
     - name: Store GitHub actions ENV from AWS SecretManager
-      uses: say8425/aws-secrets-manager-actions@v2
+      uses: say8425/aws-secrets-manager-actions@v2.2.1
       with:
         AWS_DEFAULT_REGION: "eu-west-2"
         SECRET_NAME: "di-mobile-android-onelogin-app/github-actions-env-v2"
 
     - name: Store Google Play Service ENV from AWS SecretManager
-      uses: say8425/aws-secrets-manager-actions@v2
+      uses: say8425/aws-secrets-manager-actions@v2.2.1
       with:
         AWS_DEFAULT_REGION: "eu-west-2"
         SECRET_NAME: "di-ipv-dca-mob-android/google-play-service-account-json-v2"


### PR DESCRIPTION
Update was-secrets-manager-actions to version 2.2.1

[DCMAW-6679](https://govukverify.atlassian.net/jira/software/c/projects/DCMAW/boards/371?selectedIssue=DCMAW-6679)

[DCMAW-6679]: https://govukverify.atlassian.net/browse/DCMAW-6679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ